### PR TITLE
Common English language things

### DIFF
--- a/tex/chHierarchy.tex
+++ b/tex/chHierarchy.tex
@@ -158,8 +158,8 @@ canonical instance. After line 2 all the additive algebra provided in
 \lib{ssralg} becomes applicable to \lstinline/'I_p/; for example \C{0}
 denotes the zero element, and \C{i + 1} denotes the successor of \C{i} mod $p$.
 
-The \C{ZmodMixin} constructor infers the operations \C{Zp_add}, ...,
-from the identities \C{Zp_add0z}, ... Providing an explicit definition
+The \C{ZmodMixin} constructor infers the operations \C{Zp_add}, etc.,
+from the identities \C{Zp_add0z}, etc.. Providing an explicit definition
 for the mixin, rather than inlining it in line 2, is important as it
 speeds up type checking, which never need to open the mixin bundle.
 

--- a/tex/chNumbers.tex
+++ b/tex/chNumbers.tex
@@ -10,7 +10,7 @@ complex numbers.
 
 \item
 Natural numbers $\mathbb{N}$ play a special role in the \mcbMC{} library as they
-are such a basic notion that many other concept needs it (eg sequences, ...).
+are such a basic notion that many other concept needs it (eg sequences, \ldots).
 The definition of elementary arithmetic operations on natural numbers
 is given and studied in \lib{ssreflect.ssrnat}, except for division
 that is given in \lib{ssreflect.div}.  Elementary properties of

--- a/tex/chNumbers.tex
+++ b/tex/chNumbers.tex
@@ -10,7 +10,7 @@ complex numbers.
 
 \item
 Natural numbers $\mathbb{N}$ play a special role in the \mcbMC{} library as they
-are such a basic notion that many other concept needs it (eg sequences, \ldots).
+are such a basic notion that many other concept needs it (e.g., sequences, \ldots).
 The definition of elementary arithmetic operations on natural numbers
 is given and studied in \lib{ssreflect.ssrnat}, except for division
 that is given in \lib{ssreflect.div}.  Elementary properties of

--- a/tex/chProgramming.tex
+++ b/tex/chProgramming.tex
@@ -825,14 +825,14 @@ A fundamental principle is enforced by \Coq{} on case analysis:
 the inductive type.  For example, the following definition is
 rejected by \Coq{}.
 
-\begin{coq}{name=f_plus_one}{width=6cm,title=Non exhaustive case analysis}
+\begin{coq}{name=f_plus_one}{width=6cm,title=Non-exhaustive case analysis}
 Definition wrong (n : nat) :=
   match n with 0 => true end.
 $~$
 \end{coq}
 \coqrun{name=f_plus_one_run}{f_plus_one}
 \begin{coqout}{f_plus_one_run}{width=6cm,title=Response}
-Error: Non exhaustive pattern
+Error: Non-exhaustive pattern
 matching: no clause found for
 pattern S _
 \end{coqout}
@@ -2074,8 +2074,8 @@ Notation                                       Scope
 
 The only difficulty in using \C{Locate} comes from the fact
 that one has to provide a complete \emph{symbol}.  A symbol
-is composed by one or more non blank characters and its first
-character is necessarily a non alphanumerical one.
+is composed by one or more non-blank characters and its first
+character is necessarily a non-alphanumerical one.
 The converse is not true: a sequence of characters is recognized as
 a symbol only if it is used in a previously declared notation.
 For example \C{3.+1.+1 } is parsed as a number followed by two
@@ -2386,7 +2386,7 @@ Definition all_words n T (alphabet : seq T) :=
 %
 % Examples and exercises can be executed in an empty context, or
 % libraries can be required for the purpose of (re)using and combine existing
-% programs (non proofs here).
+% programs (non-proofs here).
 %
 % The current contents are organized like the tutorial at ITP15 I gave (Enrico).
 % It was on standard \Coq{} and was intended not to be difficult class ;-)
@@ -2646,7 +2646,7 @@ Definition all_words n T (alphabet : seq T) :=
 % Check true :: false :: nil.
 % Fail Check 1 :: false :: nil.
 %
-% (* A non recursive function on lists *)
+% (* A non-recursive function on lists *)
 % Definition tl A (l : list A) : list A :=
 %   match l with
 %   | nil => nil

--- a/tex/chProgramming.tex
+++ b/tex/chProgramming.tex
@@ -135,7 +135,7 @@ uniform way. A type annotation has the shape \C{(t : T)}, where a colon
 left from the type \C{T} itself on the right. For instance in
 \C{(n : nat)}, the argument \C{n} of the function \C{f} is annotated with
 type \C{nat}. The second occurrence \C{ ... : nat := ...} of type
-\C{nat} annotates the output of the function with type \C{nat} --that is any
+\C{nat} annotates the output of the function with type \C{nat} --- that is any
 expression made of the application of \C{f} to an argument.
 \index[concept]{type}
 

--- a/tex/chProofs.tex
+++ b/tex/chProofs.tex
@@ -2334,7 +2334,7 @@ Lemma size_all_words n T (alphabet : seq T) :
 \end{coq}
 
 It requires two inductions: first on the length of words,
-then on the alphabet.  In this last case, a non trivial
+then on the alphabet.  In this last case, a non-trivial
 sub expression has to be generalized just before starting
 the induction.
 
@@ -2902,7 +2902,7 @@ Qed.
 % \subsection{proof term for rewrite (CH)}
 %
 % There are also proof terms for equality proofs (show \C{refl})
-% The work rewrite does is non trivial (infer P)
+% The work rewrite does is non-trivial (infer P)
 %
 % \begin{coq}{}
 % Check eq_rect (* : forall P : nat -> Prop, .... forall n, P n *)
@@ -2944,7 +2944,7 @@ Qed.
 % % From calculability to proofs, hence the CC, and the fact that
 % % reasoning principles without a computational content become axioms.
 % %
-% % This is a non technical chapter and message should be:
+% % This is a non-technical chapter and message should be:
 % % \begin{itemize}
 % % \item instantiation of a universal statement is application (also the pair)
 % % \item Excluded middle is not available by default (choice?)

--- a/tex/chProofs.tex
+++ b/tex/chProofs.tex
@@ -1207,7 +1207,7 @@ leqn0 : forall n : nat, (n <= 0) = (n == 0)
 
 She has thus observed that \Coq{}'s output features a prenex
 \C{forall} quantifier. This universal quantifier binds a natural number, and
-expresses --as expected-- that the equation holds for \emph{any}
+expresses --- as expected --- that the equation holds for \emph{any}
 natural number. In fact, the type of the lemmas and theorems with
 parameters all feature prenex universal quantifiers:
 
@@ -1714,7 +1714,7 @@ To sum up reasoning by induction on a term \C{t} means
 finding the induction lemma associated to the type of \C{t}
 \emph{and} synthesizing
 the right predicate \C{P}.  The \C{elim:} tactic has these two
-functionalities --while \C{apply:} does not. The induction principle
+functionalities --- while \C{apply:} does not. The induction principle
 to be used is guessed from the type of the argument of the tactic. Let
 us illustrate on an example how the value of the parameter \C{P} is
 guessed by the \C{elim:} tactic and let us prove by induction on \C{m}

--- a/tex/chSigmaBool.tex
+++ b/tex/chSigmaBool.tex
@@ -676,7 +676,7 @@ What \C{ord\_enum} produces is hence a sequence of ordinals, i.e.,
 a sequence of terms like \C{(@Ordinal m p)} where \C{m} is a natural
 number (as produced by \C{iota}) and \C{p} is a proof that \C{(m <=
 n)}.  What we are left to show is that such an enumeration is complete
-and non redundant.
+and non-redundant.
 
 \begin{coq}{}{}
 Lemma val_ord_enum : map val ord_enum = iota 0 n.

--- a/tex/chSpecification.tex
+++ b/tex/chSpecification.tex
@@ -65,7 +65,7 @@ introduces in the context of the goal a natural number \C{n : nat} and
 the fact \C{(asn : a (nth x0 s n))}. In order to establish that
 \C{(has_prop a x0 s)}, we cannot resort to computation. Instead, we can
 prove it by providing the index at which a witness is
-to be found  --plus a proof of this fact-- which may be better suited
+to be found  --- plus a proof of this fact --- which may be better suited
 for instance to an abstract sequence \C{s}.
 
 In summary, boolean statements are especially convenient for excluded

--- a/tex/chSpecification.tex
+++ b/tex/chSpecification.tex
@@ -158,7 +158,7 @@ We could try
 alternative formulations based on the connectives seen in
 section~\ref{ch:ttch}, like for instance
 \C{(b = true /\\ P) \\/ (b = false /\\ ~ P)}, but again the bureaucracy
-would be non negligible.
+would be non-negligible.
 
 A better solution is
 to use an ad-hoc inductive definition that resembles a
@@ -512,7 +512,7 @@ in \C{Prop} with the ease to reason by equivalence via rewriting
 of boolean identities leads to concise proofs.
 }
 
-Let us now move to a non artificial example to see how the Ssreflect
+Let us now move to a non-artificial example to see how the Ssreflect
 tactic language supports the combination of views with the \C{apply},
 \C{case} and \C{rewrite} tactics.
 
@@ -1095,7 +1095,7 @@ The proof goes like that: without loss of generality we can assume that
 $n_2$ is greater or equal to $n_1$, hence $n_2$ is the maximum between
 $n_1$ and $n_2$.  Under this assumption it is sufficient to check
 that $m \le n_2$ holds iff either $m \le n_2$ or $m \le n_1$.
-The only non trivial case is when we suppose $m \le n_1$ and
+The only non-trivial case is when we suppose $m \le n_1$ and
 we need to prove $m \le n_2$ which holds by transitivity.\hfill$\square$
 
 As usual we model double implication as an equality between two
@@ -1429,7 +1429,7 @@ Lemma subn_if_gt T m n F (E : T) :
     (if n <= m then F (m - n) else E).
 \end{coq}
 
-The else branch corresponds to the non recursive case of
+The else branch corresponds to the non-recursive case of
 the division algorithm and is trivially solved in line 6.
 The recursive call is done on \C{(m-d)}, hence the need for a strong
 induction.  In order to satisfy the premise of the induction hypothesis,

--- a/tex/chSpecification.tex
+++ b/tex/chSpecification.tex
@@ -70,7 +70,7 @@ for instance to an abstract sequence \C{s}.
 
 In summary, boolean statements are especially convenient for excluded
 middle arguments and its variants (reductio ad
-absurdum,...). They furthermore provide a form of small-step
+absurdum, \ldots). They furthermore provide a form of small-step
 automation by computation.\footnote{They moreover allow for
   proof-irrelevant specifications. This feature is largely used
   throughout the Mathematical Components library but beyond the scope
@@ -79,7 +79,7 @@ automation by computation.\footnote{They moreover allow for
 Specifications in the \C{Prop} sort
 are structured logical statements, that can be ``destructed'' to
 provide witnesses (of existential statements), instances (of universal
-statements), subformulae (of conjunctions),... They are proved by
+statements), subformulae (of conjunctions), etc.. They are proved by
 deduction, building proof trees made with the rules of the
 logic. Formalizing a predicate by the means of a boolean specification
 requires implementing a form of decision

--- a/tex/chTT.tex
+++ b/tex/chTT.tex
@@ -483,7 +483,7 @@ Definition proj1 A B (p : A /\ B) : A :=
 \index[coq]{\C{conj}}
 
 Now recall the similarity between $\to$ and $\forall$, where the former is the
-simple, non dependent case of the latter.  If we ask for the type of
+simple, non-dependent case of the latter.  If we ask for the type of
 the \C{conj} constructor:
 
 \begin{coq}{name=Ande1}{width=4cm}

--- a/tex/chTT.tex
+++ b/tex/chTT.tex
@@ -506,7 +506,7 @@ Notation "'exists' x : A , p" := (ex A (fun x : A => p)).
 
 As  \C{ex\_intro} is the only constructor of the \C{ex} inductive
 type, it is the only mean to prove a statement like
-\C{(exists n, prime n)}.  In such a --constructive-- proof, the first
+\C{(exists n, prime n)}.  In such a --- constructive --- proof, the first
 argument would be a number
 \C{n} of type \C{nat} while the second argument would be a proof \C{p} of type
 \C{(prime n)}.  The parameter \C{P} causes the dependency of the

--- a/tex/chTypeInference.tex
+++ b/tex/chTypeInference.tex
@@ -1321,7 +1321,7 @@ is provided as the combination of two simpler lemmas called
 respectively \C{big\_nat\_recr} and \C{big\_mkcond}.
 
 The former states that one can pull out of an iterated operation on a
-numerical range the last element, proviso the range is non empty.
+numerical range the last element, proviso the range is non-empty.
 
 \begin{coq}{name=bigop3natrec}{}
 Lemma big_nat_recr n m F : m <= n ->


### PR DESCRIPTION
1. Added hyphens after non.  E.g., "non blank" becomes "non-blank"
2. Fixed E.g. notation.   "(eg" became "(e.g., "
3. Changed ... into "etc." outside of parentheses and into "\ldots" inside parentheses.  
    NOTE: I did not do this command inside Coq example code.  For proper TeX, it probably should be.
4. Changed en-dashes without spacing into em-dashes with spacing.  E.g., "--emphasized--" becomes "--- emphasized ---".

These were changes that could be easily located with grep.  
  en-dashes found with command:
    grep -- -- *.tex | grep -v -- ---
  ... found with command:
    grep "\.\.\." *.tex | grep -v %

