### PR TITLE
Trying to fix date's output format

### DIFF
--- a/tex/Makefile
+++ b/tex/Makefile
@@ -10,7 +10,7 @@ all: gitrev
 	pdflatex main && cp main.pdf book.pdf
 .PHONY: gitrev
 gitrev:
-	date > gitrev
+	date -R > gitrev
 	echo , >> gitrev
 	git describe --tags >> gitrev
 


### PR DESCRIPTION
Both BSD date and GNU date produce the same output on macOS with -R option.
Without this change the date utility may produce non-ASCII symbols, depending on the locale.

d0c9970cd8a27c70ea977dc95aa940c58c87742b broke the build for me because of the `gitrev` change.