### PR TITLE
Fix minor typos in ch 3.

### DIFF
--- a/tex/chTT.tex
+++ b/tex/chTT.tex
@@ -12,7 +12,7 @@ to the methodology at the base of the \mcbMC{} library. The present chapter is
 devoted to a more in-depth presentation of these mathematical
 foundations, although an exhaustive description shall remain out of
 the scope of the present book. For more comprehensive presentations of
-type theory for formalized mathematics, the reader shall refer to more
+type theory for formalized mathematics, the reader can refer to more
 specialized references like~\cite{ttfp}, or the
 shorter survey in the Handbook of Automated
 Reasoning~\cite[Volume 2, chapter 18]{handbook-ar}.
@@ -727,9 +727,9 @@ using a compact, symbolic, language.  Note that all bookkeeping actions
 correspond to regular, named, proof commands.  It is the use one makes of them
 that may be twofold: a case analysis in the middle of a proof may start two
 distinct lines of reasoning, and hence it is worth being noted explicitly with
-the \C{case} word. Conversly, breaking a pair into two pieces is
+the \C{case} word. Conversely, breaking a pair into two pieces is
 usually not a significant, meaningful step in a proof: hence the
-possiblity to use a lightwight and compact syntax for this bookkeeping
+possibility to use a lightweight and compact syntax for this bookkeeping
 action, instead of an explicit mention of the \C{case} tactic.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1180,7 +1180,7 @@ The only missing piece is recursive programs.  For example,
 function taking as input two numbers and producing a third one.
 We can write programs by recursion that take as input, among regular  data,
 proofs and produce  other proofs as output.  Let's look at the
-induction principle for natural numbers trough the looking glasses of the
+induction principle for natural numbers through the looking glasses of the
 Curry-Howard isomorphism.
 
 \begin{coq}{}{width=3.5cm}


### PR DESCRIPTION
This was a great chapter with nice explanations of the tactics.

ltnW, leq_subLR, addSnnS, leq_addl, leq_trans, mulSn, subnKC were used without definition, almost all in the last example.
Also, the 'On the status of Axioms' seemed quite advanced for this early chapter, perhaps needs a 
star?