### PR TITLE
Fix text formatting (no space between text and formula)

### DIFF
--- a/tex/chTT.tex
+++ b/tex/chTT.tex
@@ -390,7 +390,7 @@ Set : Type@{U4} (* Set < U3 *)
 
 Terms \C{nat}, \C{bool}, \C{Prop} are simple, atomic types, which can be used
 to build non-atomic ones. For instance, in Chapter~\ref{ch:proofs}, we
-met the type of functions from natural numbers to boolean, which is\C{nat -> bool}.
+met the type of functions from natural numbers to boolean, which is \C{nat -> bool}.
 Similarly the type of addition over natural numbers is 
 \C{nat -> nat -> nat}, and the type of boolean negation is 
 \C{bool -> bool}.


### PR DESCRIPTION
Hello!
There is no space between text at formula in one sentence in 3rd chapter.
It looks like [this](https://imgur.com/a/YECUy85) ("which isnat-> bool.")