### PR TITLE
Fix invalid variable name, so that example code compiles

### DIFF
--- a/tex/chSpecification.tex
+++ b/tex/chSpecification.tex
@@ -1031,8 +1031,8 @@ Proof. by []. Qed.
 \end{coq}{}{}
 \index[coq]{\C{ubnPgeq}}
 
-As a consequence by performing a case analysis on \C{(ubnPgeq n)} one
-obtains the same effect of \C{move: {-2}n (leqnn n)}.
+As a consequence by performing a case analysis on \C{(ubnPgeq m)} one
+obtains the same effect of \C{move: {-2}m (leqnn m)}.
 
 \begin{coq}{}{}
 Lemma test_ubnP (G : nat -> Prop) m : G m.

--- a/tex/chSpecification.tex
+++ b/tex/chSpecification.tex
@@ -1035,15 +1035,15 @@ As a consequence by performing a case analysis on \C{(ubnPgeq n)} one
 obtains the same effect of \C{move: {-2}n (leqnn n)}.
 
 \begin{coq}{}{}
-Lemma test_ubnP (G : nat -> Prop) n : G n.
+Lemma test_ubnP (G : nat -> Prop) m : G m.
 Proof.
 case: (ubnPgeq m).
 \end{coq}{}{}
 \begin{coqout}{}{}
 G : nat -> Prop
-n : nat
+m : nat
 ============================
-forall m, m <= n -> G m
+forall n, n <= m -> G n
 \end{coqout}{}{}
 
 By varying the arguments of the inductive specification constructor one


### PR DESCRIPTION
Hello!

Example of inductive specs at chapter 5 uses variable named `n` in the hypothesis, but refers to `m` in the proof (`ubnPgeq m`).
I changed `n` to `m` and not the other way around, because it gives nicer output (Coq 8.13.0, Mathcomp 1.12.0).
When variable is `m`: `forall n : nat, n <= m -> G n`
When variable is `n`: `forall n0 : nat, n0 <= n -> G n0`
