### PR TITLE
fix: :pencil2: correct a typo found in our study group CoqTokyo.

### DIFF
--- a/tex/chProofs.tex
+++ b/tex/chProofs.tex
@@ -1467,7 +1467,7 @@ Lemma chinese_remainder x y :
   (x == y %[mod m1 * m2]) = (x == y %[mod m1]) && (x == y %[mod m2]).
 Proof.
 ...
-End.
+Qed.
 
 End Chinese.
 \end{coq}


### PR DESCRIPTION
Corrected a typo found in our study group CoqTokyo.