### PR TITLE
Fixed typo on page 72

### DIFF
--- a/tex/chTT.tex
+++ b/tex/chTT.tex
@@ -384,7 +384,7 @@ hierarchy of \C{Type}:
 Check Set : Type.
 \end{coq-left}
 \begin{coqout-right}
-Set : Type@{U4} (* Set < U3 *)
+Set : Type@{U4} (* Set < U4 *)
 \end{coqout-right}
 \coqrun{name=r2}{ssr,check-set}
 


### PR DESCRIPTION
U4 was replaced by U3 on page 72, ch3, section 3.2 :

> In an empty context, the term Prop has type Type (for any value of the index) :
 Check Prop : Type.
 Prop : Type@{U3} (* Prop < U3 \*)
Set happens to be a name for the smallest element of the hierarchy of Type :
 Check Set : Type.
 Set : Type@{U4} (* Set < U3 *)

I rewrote U3 with U4.
(i hope i am right !)